### PR TITLE
added BCrypt and Gravatarify gems to our gemfile :metal:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem 'rake'
 
 gem 'shotgun'
 
+gem 'bcrypt'
+
+gem 'gravatarify', '~> 3.0.0'
+
 group :test do
   gem 'shoulda-matchers'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     backports (3.6.0)
+    bcrypt (3.1.10)
     builder (3.2.2)
     capybara (2.2.1)
       mime-types (>= 1.16)
@@ -23,13 +24,12 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    daemons (1.1.9)
     diff-lcs (1.2.5)
-    eventmachine (1.0.3)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
     faker (1.3.0)
       i18n (~> 0.5)
+    gravatarify (3.0.0)
     i18n (0.6.9)
     json (1.8.1)
     mime-types (2.3)
@@ -68,10 +68,6 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (~> 1.3)
-    thin (1.6.2)
-      daemons (>= 1.0.9)
-      eventmachine (>= 1.0.0)
-      rack (>= 1.0.0)
     thread_safe (0.3.4)
     tilt (1.4.1)
     tzinfo (1.2.0)
@@ -85,9 +81,11 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.1)
   activesupport (~> 4.1)
+  bcrypt
   capybara
   factory_girl
   faker
+  gravatarify (~> 3.0.0)
   pg
   rack-test
   rake
@@ -96,4 +94,3 @@ DEPENDENCIES
   shoulda-matchers
   sinatra
   sinatra-contrib
-  thin


### PR DESCRIPTION
Gravatarify is a gem that allows you to take the User's email and convert that into their Gravatar img hash. Documentation here: https://github.com/lwe/gravatarify
